### PR TITLE
test_nav_parent_switch_cast.rs

### DIFF
--- a/spec/rust/tests/test_nav_parent_recursive.rs
+++ b/spec/rust/tests/test_nav_parent_recursive.rs
@@ -1,0 +1,26 @@
+#![allow(unused_variables)]
+#![allow(unused_assignments)]
+#![allow(overflowing_literals)]
+use std::fs;
+extern crate kaitai;
+use self::kaitai::*;
+use rust::formats::nav_parent_recursive::*;
+
+#[test]
+fn test_nav_parent_recursive() {
+    let bytes = fs::read("../../src/enum_negative.bin").unwrap();
+    let _io = BytesReader::from(bytes);
+    let res: KResult<OptRc<NavParentRecursive>> = NavParentRecursive::read_into(&_io, None, None);
+    let r: OptRc<NavParentRecursive>;
+
+    if let Err(err) = res {
+        panic!("{:?}", err);
+    } else {
+        r = res.unwrap();
+    }
+
+    assert_eq!(*r.value(), 255);
+    assert_eq!(*r.next().value(), 1);
+    assert_eq!(*r.next().parent_value().unwrap(), 255);
+    assert!(r.next().next().is_none());
+}

--- a/spec/rust/tests/test_nav_parent_switch_cast.rs
+++ b/spec/rust/tests/test_nav_parent_switch_cast.rs
@@ -1,0 +1,26 @@
+//test_nav_parent_switch_cast.rs
+#![allow(unused_variables)]
+#![allow(unused_assignments)]
+#![allow(overflowing_literals)]
+use std::fs;
+
+extern crate kaitai;
+use self::kaitai::*;
+use rust::formats::nav_parent_switch_cast::*;
+
+#[test]
+fn test_nav_parent_switch_cast() {
+    let reader = BytesReader::open("switch_integers.bin").unwrap();
+    let r: kaitai::OptRc<NavParentSwitchCast> =
+        NavParentSwitchCast::read_into(&reader, None, None).unwrap();
+
+    let r_main = r.main();
+    assert_eq!(*r_main.buf_type(), 1);
+    assert_eq!(*r_main.flag(), 7);
+    let x = r_main.buf().clone();
+    if let Some(NavParentSwitchCast_Foo_Buf::NavParentSwitchCast_Foo_One(ref one)) = x {
+        assert_eq!(*one.branch().flag().unwrap(), 7);
+    } else {
+        unreachable!()
+    }
+}

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/Main.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/Main.scala
@@ -81,8 +81,8 @@ object Main extends App {
       c.copy(srcFiles = list.toSeq)
     } text("process all KST files available")
 
-    opt[Unit]('f', "force") action { (x, c) =>
-      c.copy(outDir = specDir)
+    opt[String]('f', "force") action { (x, c) =>
+      c.copy(outDir = x)
     } text(s"force overwrite specs in production spec dirs (default: generate in $defaultOutDir)")
 
     checkConfig(


### PR DESCRIPTION
all mentioned in `Only 4 tests from kaitai_struct_tests not supported` were gone from `build_failed_files.txt`